### PR TITLE
feat: 공통 Button 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,20 @@
+import { twMerge } from 'tailwind-merge';
+
+type TButtonProps = React.ComponentPropsWithoutRef<'button'>;
+
+const Button = (props: TButtonProps) => {
+  const { className, children, ...rest } = props;
+
+  return (
+    <>
+      <button
+        className={twMerge(`bg-black text-white text-base font-medium w-full h-[56px] rounded`, className)}
+        {...rest}
+      >
+        {children}
+      </button>
+    </>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
## 📝 작업 내용

> 공통 Button 구현

### 📸 스크린샷 (선택)

> ![Pasted Graphic 6](https://github.com/user-attachments/assets/087894c7-37c7-44b2-9fc9-c1b94d5108aa)


## 💬 리뷰 요구사항 (선택)

- 피그마에서 가장 많이 사용된 버튼 디자인을 기본 값으로 설정해 두었습니다. 사진과 같은 버튼 디자인이라면 외부 padding 값 고려하여 바로 사용하셔도 됩니다.
- w-full로 지정해두었으니 버튼의 크기가 약간씩 다른 경우, 부모 태그의 padding을 조절하여 원하는 버튼 크기를 지정해주시면 됩니다.
- 다른 디자인의 경우 버튼 컴포넌트 props로 className 적용해주시면 twMerge 통해서 작성하신대로 디자인 적용 됩니다. 
- 현재 버튼 height는 피그마 디자인에 맞춰 px 단위로 설정해 두었는데 추후 반응형 디자인 고려하여 조정될 수 있습니다.
