### PR TITLE
fix: Image rounded cut

### DIFF
--- a/src/pages/Bridge.tsx
+++ b/src/pages/Bridge.tsx
@@ -2,24 +2,20 @@ import bridge from '../assets/images/bridge.jpg';
 
 const Bridge = () => {
   return (
-    <div className='h-full flex flex-col'>
-      <div className='flex flex-1 justify-center'>
-        <div className='flex flex-col h-[342px]  items-center'>
-          <div className='pt-[188px]'>
-            <img
-              src={bridge}
-              alt='bridge_img'
-              width='120px'
-              height='120px'
-            />
+    <div className='h-full flex flex-col justify-center'>
+      <div className='flex flex-1 flex-col justify-center items-center'>
+        <img
+          src={bridge}
+          alt='bridge_img'
+          className='w-[120px] h-[120px] rounded-full'
+        />
+
+        <div className='pt-[38px] text-center'>
+          <div className='text-[18px] font-normal leading-7'>[Crocs] 올 터레인 클로그 블랙</div>
+          <div className='text-[18px] font-semibold leading-6 py-[16px]'>
+            ABC MART로 <br /> 이동 중입니다.
           </div>
-          <div className='pt-[38px] h-[132px] text-center'>
-            <div className='text-[18px] font-normal leading-7'>[Crocs] 올 터레인 클로그 블랙</div>
-            <div className='text-[18px] font-semibold leading-6 py-[16px]'>
-              ABC MART로 <br /> 이동 중입니다.
-            </div>
-            <div className='text-[16px] font-normal text-[#808080] leading-6'>잠시만 기다려 주세요.</div>
-          </div>
+          <div className='text-[16px] font-normal text-[#808080] leading-6'>잠시만 기다려 주세요.</div>
         </div>
       </div>
     </div>

--- a/src/pages/Bridge.tsx
+++ b/src/pages/Bridge.tsx
@@ -4,11 +4,13 @@ const Bridge = () => {
   return (
     <div className='h-full flex flex-col justify-center'>
       <div className='flex flex-1 flex-col justify-center items-center'>
-        <img
-          src={bridge}
-          alt='bridge_img'
-          className='w-[120px] h-[120px] rounded-full'
-        />
+        <div className='w-[120px] h-[120px] overflow-hidden rounded-full'>
+          <img
+            src={bridge}
+            alt='bridge_img'
+            className='w-full h-full object-contain'
+          />
+        </div>
 
         <div className='pt-[38px] text-center'>
           <div className='text-[18px] font-normal leading-7'>[Crocs] 올 터레인 클로그 블랙</div>


### PR DESCRIPTION
## 📝 작업 내용

> 이미지를 원형으로 자르도록 코드를 추가했습니다. 

### 📸 스크린샷 (선택)

> ![image](https://github.com/user-attachments/assets/a1a876a7-9e35-484e-acfa-ec69aac33497)
![image](https://github.com/user-attachments/assets/76e24f2a-cae3-4f54-b698-6f535a93f261)


## 💬 리뷰 요구사항 (선택)

> 임의로 검은색 이미지로 테스트해봤습니다. 실제 피그마에 있는 이미지로 적용해도 잘 나옵니다. 
